### PR TITLE
opts in json

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,10 @@ from .differ import Differ
 from .scroll import ScrollSplittedTab
 from .ui import DifferDialog, file_history
 
+import json
+import cudax_lib    as ctx
+import cuda_options_editor as op_ed
+
 
 DIFF_TAG = 148
 NKIND_DELETED = 24
@@ -15,6 +19,73 @@ DECOR_CHAR = '■'
 INIFILE = os.path.join(ct.app_path(ct.APP_DIR_SETTINGS), 'cuda_differ.ini')
 DEFAULT_SYNC_SCROLL = '1'
 
+
+METAJSONFILE = os.path.dirname(__file__)+os.sep+'differ_opts.json'
+JSONFILE     = 'cuda_differ.json'    # To store in settings/cuda_differ.json
+OPTS_META    = [
+    {'opt':'differ.changed_color',
+     'cmt':'Color of changed lines',
+     'def':'',
+     'frm':'#rgb-e',
+     'chp':'colors',
+    },
+    {'opt':'differ.added_color',
+     'cmt':'Color of added lines',
+     'def':'',
+     'frm':'#rgb-e',
+     'chp':'colors',
+    },
+    {'opt':'differ.deleted_color',
+     'cmt':'Color of deleted lines',
+     'def':'',
+     'frm':'#rgb-e',
+     'chp':'colors',
+    },
+    {'opt':'differ.gap_color',
+     'cmt':'Color of inter-line gap background',
+     'def':'',
+     'frm':'#rgb-e',
+     'chp':'colors',
+    },
+    {'opt':'differ.enable_scroll_default',
+     'cmt':'Enable automatical sync-scrolling in both compared files',
+     'def':True,
+     'frm':'bool',
+     'chp':'config',
+    },
+    {'opt':'differ.compare_with_details',
+     'cmt':'Detailed compare',
+     'def':True,
+     'frm':'bool',
+     'chp':'config',
+    },
+    {'opt':'differ.ratio',
+     'cmt':'Measure of the sequences’ similarity, float value in the range [0, 1]',
+     'def': 0.75,
+     'frm':'float',
+     'chp':'config',
+    },
+]
+
+USE_INI = False
+USE_INI_AS_DEFAULT_FOR_JSON = True
+def get_opt(section, key, dval=''):
+    if USE_INI:
+        return type(dval)(
+                ct.ini_read(INIFILE,  section,    key, str(dval))
+            )
+    else:   # in user.json
+        dval = type(dval)(
+                ct.ini_read(INIFILE,  section,    key, str(dval))
+             ) if USE_INI_AS_DEFAULT_FOR_JSON and os.path.exists(INIFILE) else dval
+        return  ctx.get_opt('differ.'+section+'.'+key,     dval,    user_json=JSONFILE) if ctx.version(0)>='0.6.8' else \
+                ctx.get_opt('differ.'+section+'.'+key,     dval)
+
+#def set_opt(section, key, val):
+#   if USE_INI:
+#       ct.ini_write(INIFILE,        section,    key, str(val))
+#   else:   # in user.json
+#       return ctx.set_opt('differ.'+section+'.'+key,     val,      user_json=JSONFILE)
 
 def msg(s, level=0):
     PLG_NAME = 'Differ'
@@ -34,8 +105,20 @@ class Command:
         self.scroll = ScrollSplittedTab(__name__)
 
     def change_config(self):
-        self.config()
-        ct.file_open(INIFILE)
+        if USE_INI:
+            self.config()
+            ct.file_open(INIFILE)
+        else:
+            if not os.path.exists(   METAJSONFILE):     # Create meta-info file if no one
+                open(METAJSONFILE, 'w').write(json.dumps(OPTS_META, indent=4))
+            if op_ed.OptEdD(
+                    path_keys_info = METAJSONFILE,
+                    subset = 'differ.',                 # Key to isolate settings for op_ed plugin
+                    how = dict(hide_lex_fil=True,       # If option has not setting for lexer/cur.file
+                               stor_json = JSONFILE),
+                ).show('Differ Options'):               # Dialog caption
+               # Need to use updated options
+               print('Applying options...')
 
     def choose_files(self):
         files = self.diff_dlg.run()
@@ -201,16 +284,17 @@ class Command:
 
     def get_config(self):
         if not os.path.exists(INIFILE):
-            ct.ini_write(INIFILE, 'colors', 'changed', '')
-            ct.ini_write(INIFILE, 'colors', 'added', '')
-            ct.ini_write(INIFILE, 'colors', 'deleted', '')
-            ct.ini_write(INIFILE, 'colors', 'gap', '')
+            ct.ini_write(INIFILE, 'colors', 'changed_color', '')
+            ct.ini_write(INIFILE, 'colors', 'added_color', '')
+            ct.ini_write(INIFILE, 'colors', 'deleted_color', '')
+            ct.ini_write(INIFILE, 'colors', 'gap_color', '')
             ct.ini_write(INIFILE, 'config', 'enable_scroll_default', DEFAULT_SYNC_SCROLL),
             ct.ini_write(INIFILE, 'config', 'compare_with_details', '1'),
             ct.ini_write(INIFILE, 'config', 'ratio', '0.75')
 
         def get_color(key, default_color):
-            s = ct.ini_read(INIFILE, 'colors', key, '')
+            s = get_opt(             'colors', key, '')
+           #s = ct.ini_read(INIFILE, 'colors', key, '')
             f = s.find('#') == 0
             s = s.strip().lstrip('#')
             slen = len(s)
@@ -253,13 +337,16 @@ class Command:
         config = {
             'ini_time': os.path.getmtime(INIFILE),
             'theme_name': ct.app_proc(ct.PROC_THEME_SYNTAX_GET, ''),
-            'color_changed': get_color('changed', t.get('color_changed')),
-            'color_added': get_color('added', t.get('color_added')),
-            'color_deleted': get_color('deleted', t.get('color_deleted')),
-            'color_gaps': get_color('gap', ct.COLOR_NONE),
-            'enable_scroll': ct.ini_read(INIFILE, 'config', 'enable_scroll_default', DEFAULT_SYNC_SCROLL) == '1',
-            'compare_with_details': ct.ini_read(INIFILE, 'config', 'compare_with_details', '1') == '1',
-            'ratio': float(ct.ini_read(INIFILE, 'config', 'ratio', '0.75'))
+            'color_changed':    get_color('changed_color',  t.get('color_changed')),
+            'color_added':      get_color('added_color',    t.get('color_added')),
+            'color_deleted':    get_color('deleted_color',  t.get('color_deleted')),
+            'color_gaps':       get_color('gap_color',      ct.COLOR_NONE),
+            'enable_scroll': get_opt(             'config', 'enable_scroll_default', DEFAULT_SYNC_SCROLL == '1'),
+           #'enable_scroll': ct.ini_read(INIFILE, 'config', 'enable_scroll_default', DEFAULT_SYNC_SCROLL) == '1',
+            'compare_with_details': get_opt(             'config', 'compare_with_details', True),
+           #'compare_with_details': ct.ini_read(         'config', 'compare_with_details', '1') == '1',
+            'ratio': get_opt(                   'config', 'ratio',  0.75)
+           #'ratio': float(ct.ini_read(INIFILE, 'config', 'ratio', '0.75'))
         }
 
         new_nkind(NKIND_DELETED, config.get('color_deleted'))

--- a/install.inf
+++ b/install.inf
@@ -28,7 +28,7 @@ method=jump_prev
 
 [item10]
 section=commands
-caption=Differ\Config
+caption=Differ\Config...
 method=change_config
 menu=o
 

--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,4 +1,8 @@
 
+2019.04.29
++ add: store options into json-file
++ add: edit options with cuda_options_editor
+
 2019.04.23
 + add: commands "Jump to next diffecence", "Jump to previous difference"
 


### PR DESCRIPTION
1. Работает с последней версией `cuda_options_editor` (в ГХ) и `cudax_lib.py` (уже в Куд)
2. Свободные имена (принять мои или задать другие)
- (23) `'differ_opts.json'` для передачи описания опций в `op_ed`, будет создан в папке плага
- (24) `'cuda_differ.json'` для хранения измененных настроек в `settings/cuda_differ.json`
- (119) `'Differ Options'` заголовок для диалога изменения опций
3. Трюк с временем модификации ini не повторял. Препятствий для этого нет.
4. После вызова диалога
(114) `if op_ed.OptEdD(...)`
нужно добавить применение обновленных опций
5. Пока можно переключаться между старым поведением (через `USE_INI`) и новым
6. Для авто-переноса настрок из ini в json добавил `USE_INI_AS_DEFAULT_FOR_JSON`. Можно будет это удалить, если перенос лишний.

Вид диалога с настройками
![image](https://user-images.githubusercontent.com/7419630/56904349-bf69ad00-6aa6-11e9-96f6-8b27ae5d92f1.png)
